### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ EXAMPLE
 ```hcl
 module "dcos-public-agent-instances" {
  source  = "dcos-terraform/public-agents/azure"
- version = "~> 0.1"
+ version = "~> 0.1.0"
 
  subnet_id = "myid"
  security_group_ids = ["sg-12345678"]"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@
  *```hcl
  *module "dcos-public-agent-instances" {
  *  source  = "dcos-terraform/public-agents/azure"
- *  version = "~> 0.1"
+ *  version = "~> 0.1.0"
  *
  *  subnet_id = "myid"
  *  security_group_ids = ["sg-12345678"]"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2